### PR TITLE
Fix 8-threads minimap in correction.py

### DIFF
--- a/scripts/correction.py
+++ b/scripts/correction.py
@@ -156,11 +156,11 @@ def polish_seq(i, ref, reads_fa, outdir, rounds, type, polish_tool,binpath=""):
     if polish_tool == 'racon':
         for k in range(rounds):
             if type == 'pb' or type == 'ont':
-                os.system("{}minimap2 --secondary=no -x map-{} -c -t 8 {} {} 2>/dev/null |cut -f 1-12 >{}"
-                          .format(binpath,type, tmp_fa, reads_fa, polish_paf))
+                os.system("{}minimap2 --secondary=no -x map-{} -c -t {} {} {} 2>/dev/null |cut -f 1-12 >{}"
+                          .format(binpath,type, 1, tmp_fa, reads_fa, polish_paf))
             elif type == 'hifi':
-                os.system("{}minimap2 --secondary=no -x asm20  -c -t 8 {} {} 2>/dev/null |cut -f 1-12 >{}".
-                          format(binpath,tmp_fa, reads_fa, polish_paf))
+                os.system("{}minimap2 --secondary=no -x asm20  -c -t {} {} {} 2>/dev/null |cut -f 1-12 >{}".
+                          format(binpath, 1, tmp_fa, reads_fa, polish_paf))
             try:
                 os.system("{}racon  -t 1 {} {} {} >{} 2>{}".format(binpath,reads_fa, polish_paf, tmp_fa, polished_fa, logfile))
             except RuntimeError as reason:


### PR DESCRIPTION
Fix the use of hard-coded 8 threads for a minimap2 task when racon correction is specified at lines 159-163.
Without fixing this, it would jam nodes in clusters, especially when running with many tasks in parallel.